### PR TITLE
mmap: expose MAP_ANON

### DIFF
--- a/mmap.cpp
+++ b/mmap.cpp
@@ -130,6 +130,7 @@ static void RegisterModule(v8::Handle<v8::Object> target)
 	target->Set(v8::String::New("PROT_NONE"), v8::Integer::New(PROT_NONE), attribs);
 	target->Set(v8::String::New("MAP_SHARED"), v8::Integer::New(MAP_SHARED), attribs);
 	target->Set(v8::String::New("MAP_PRIVATE"), v8::Integer::New(MAP_PRIVATE), attribs);
+	target->Set(v8::String::New("MAP_ANON"), v8::Integer::New(MAP_ANON), attribs);
 	target->Set(v8::String::New("PAGESIZE"), v8::Integer::New(sysconf(_SC_PAGESIZE)), attribs);
 	target->Set(v8::String::New("MS_ASYNC"), v8::Integer::New(MS_ASYNC), attribs);
 	target->Set(v8::String::New("MS_SYNC"), v8::Integer::New(MS_SYNC), attribs);

--- a/run_tests.js
+++ b/run_tests.js
@@ -106,4 +106,15 @@ global.gc();
 
 global.gc();
 
+(function(b) {
+  assert.equal(b[0],     0,             "value check (map read)");
+  assert.equal(b.length, mmap.PAGESIZE, "map length is incorrect");
+
+})( mmap(mmap.PAGESIZE, // note using wrapper (with filename)
+  mmap.PROT_READ|mmap.PROT_WRITE,
+  mmap.MAP_PRIVATE | mmap.MAP_ANON,
+  -1) );
+
+global.gc();
+
 console.log("> ok");


### PR DESCRIPTION
Hello!

I'm highly interested in using your module in my project [jit.js](https://github.com/indutny/jit.js), however it doesn't seem to support `MAP_ANON` which I really need there since I'm not working with `fd`s.

Could you please consider pulling this changes and doing a npm release?

Cheers,
Fedor.
